### PR TITLE
Update `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 SHELL := bash
 
-GO_PACKAGES?=$(shell (go list ./... | grep -v 'vendor'))
-
 .PHONY: go-test
 
 go-test:
-	go test $(GO_PACKAGES) -v $(TEST_ARGS) -timeout=15m -parallel=4
+	go test -v ./... $(TEST_ARGS) -timeout=15m -parallel=4


### PR DESCRIPTION
Delete the line that ignores the `vendor` directory from the `Go package list` as `vendor` never contains tests.