### PR TITLE
Remove dependency on go-github

### DIFF
--- a/cloudconfig/util.go
+++ b/cloudconfig/util.go
@@ -21,8 +21,7 @@ import (
 	"strings"
 
 	"github.com/cloudbase/garm-provider-common/defaults"
-	commonParams "github.com/cloudbase/garm-provider-common/params"
-	"github.com/google/go-github/v55/github"
+	"github.com/cloudbase/garm-provider-common/params"
 	"github.com/pkg/errors"
 )
 
@@ -61,7 +60,7 @@ func sortMapKeys(m map[string][]byte) []string {
 }
 
 // GetSpecs returns the cloud config specific extra specs from the bootstrap params.
-func GetSpecs(bootstrapParams commonParams.BootstrapInstance) (CloudConfigSpec, error) {
+func GetSpecs(bootstrapParams params.BootstrapInstance) (CloudConfigSpec, error) {
 	var extraSpecs CloudConfigSpec
 	if len(bootstrapParams.ExtraSpecs) == 0 {
 		return extraSpecs, nil
@@ -85,28 +84,24 @@ func GetSpecs(bootstrapParams commonParams.BootstrapInstance) (CloudConfigSpec, 
 // GetRunnerInstallScript returns the runner install script for the given bootstrap params.
 // This function will return either the default script for the given OS type or will use the supplied template
 // if one is provided.
-func GetRunnerInstallScript(bootstrapParams commonParams.BootstrapInstance, tools github.RunnerApplicationDownload, runnerName string) ([]byte, error) {
-	if tools.Filename == nil {
+func GetRunnerInstallScript(bootstrapParams params.BootstrapInstance, tools params.RunnerApplicationDownload, runnerName string) ([]byte, error) {
+	if tools.GetFilename() == "" {
 		return nil, fmt.Errorf("missing tools filename")
 	}
 
-	if tools.DownloadURL == nil {
+	if tools.GetDownloadURL() == "" {
 		return nil, fmt.Errorf("missing tools download URL")
 	}
 
-	var tempToken string
-	if tools.TempDownloadToken != nil {
-		tempToken = *tools.TempDownloadToken
-	}
-
+	tempToken := tools.GetTempDownloadToken()
 	extraSpecs, err := GetSpecs(bootstrapParams)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting specs")
 	}
 
 	installRunnerParams := InstallRunnerParams{
-		FileName:          *tools.Filename,
-		DownloadURL:       *tools.DownloadURL,
+		FileName:          tools.GetFilename(),
+		DownloadURL:       tools.GetDownloadURL(),
 		TempDownloadToken: tempToken,
 		MetadataURL:       bootstrapParams.MetadataURL,
 		RunnerUsername:    defaults.DefaultUser,
@@ -137,7 +132,7 @@ func GetRunnerInstallScript(bootstrapParams commonParams.BootstrapInstance, tool
 // GetCloudInitConfig returns the cloud-init specific userdata config. This config can be used on most clouds
 // for most Linux machines. The install runner script must be generated separately either by GetRunnerInstallScript()
 // or some other means.
-func GetCloudInitConfig(bootstrapParams commonParams.BootstrapInstance, installScript []byte) (string, error) {
+func GetCloudInitConfig(bootstrapParams params.BootstrapInstance, installScript []byte) (string, error) {
 	extraSpecs, err := GetSpecs(bootstrapParams)
 	if err != nil {
 		return "", errors.Wrap(err, "getting specs")
@@ -188,7 +183,7 @@ func GetCloudInitConfig(bootstrapParams commonParams.BootstrapInstance, installS
 // Windows initialization scripts are run by creating a separate CustomScriptExtension resource for each individual script.
 // On other clouds it may be different. This function aims to be generic, which is why it only supports the PreInstallScripts
 // via cloud-init.
-func GetCloudConfig(bootstrapParams commonParams.BootstrapInstance, tools github.RunnerApplicationDownload, runnerName string) (string, error) {
+func GetCloudConfig(bootstrapParams params.BootstrapInstance, tools params.RunnerApplicationDownload, runnerName string) (string, error) {
 	installScript, err := GetRunnerInstallScript(bootstrapParams, tools, runnerName)
 	if err != nil {
 		return "", errors.Wrap(err, "generating script")
@@ -196,13 +191,13 @@ func GetCloudConfig(bootstrapParams commonParams.BootstrapInstance, tools github
 
 	var asStr string
 	switch bootstrapParams.OSType {
-	case commonParams.Linux:
+	case params.Linux:
 		cloudCfg, err := GetCloudInitConfig(bootstrapParams, installScript)
 		if err != nil {
 			return "", errors.Wrap(err, "getting cloud init config")
 		}
 		return cloudCfg, nil
-	case commonParams.Windows:
+	case params.Windows:
 		asStr = string(installScript)
 	default:
 		return "", fmt.Errorf("unknown os type: %s", bootstrapParams.OSType)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/cloudbase/garm-provider-common
 go 1.20
 
 require (
-	github.com/google/go-github/v55 v55.0.1-0.20230921135834-aa3fcbe7aabc
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/mattn/go-isatty v0.0.19
@@ -20,6 +19,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-github/v55 v55.0.1-0.20230921135834-aa3fcbe7aabc h1:wZybOt4gfOPJmwpe3CZFJYoREaqgngGeo1Y29zZePhg=
-github.com/google/go-github/v55 v55.0.1-0.20230921135834-aa3fcbe7aabc/go.mod h1:dx9O5B1Z9+WYDRfSIkPdJ/jszShiNtl++jbgL/3OM2c=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
@@ -29,7 +23,6 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=

--- a/params/github.go
+++ b/params/github.go
@@ -1,0 +1,61 @@
+package params
+
+// RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
+// This is copied from the go-github package. It does not make sense to create a dependency on go-github just
+// for this struct.
+type RunnerApplicationDownload struct {
+	OS                *string `json:"os,omitempty"`
+	Architecture      *string `json:"architecture,omitempty"`
+	DownloadURL       *string `json:"download_url,omitempty"`
+	Filename          *string `json:"filename,omitempty"`
+	TempDownloadToken *string `json:"temp_download_token,omitempty"`
+	SHA256Checksum    *string `json:"sha256_checksum,omitempty"`
+}
+
+// GetArchitecture returns the Architecture field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetArchitecture() string {
+	if r == nil || r.Architecture == nil {
+		return ""
+	}
+	return *r.Architecture
+}
+
+// GetDownloadURL returns the DownloadURL field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetDownloadURL() string {
+	if r == nil || r.DownloadURL == nil {
+		return ""
+	}
+	return *r.DownloadURL
+}
+
+// GetFilename returns the Filename field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetFilename() string {
+	if r == nil || r.Filename == nil {
+		return ""
+	}
+	return *r.Filename
+}
+
+// GetOS returns the OS field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetOS() string {
+	if r == nil || r.OS == nil {
+		return ""
+	}
+	return *r.OS
+}
+
+// GetSHA256Checksum returns the SHA256Checksum field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetSHA256Checksum() string {
+	if r == nil || r.SHA256Checksum == nil {
+		return ""
+	}
+	return *r.SHA256Checksum
+}
+
+// GetTempDownloadToken returns the TempDownloadToken field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetTempDownloadToken() string {
+	if r == nil || r.TempDownloadToken == nil {
+		return ""
+	}
+	return *r.TempDownloadToken
+}

--- a/params/params.go
+++ b/params/params.go
@@ -16,8 +16,6 @@ package params
 
 import (
 	"encoding/json"
-
-	"github.com/google/go-github/v55/github"
 )
 
 type (
@@ -63,8 +61,8 @@ type UserDataOptions struct {
 }
 
 type BootstrapInstance struct {
-	Name  string                              `json:"name"`
-	Tools []*github.RunnerApplicationDownload `json:"tools"`
+	Name  string                      `json:"name"`
+	Tools []RunnerApplicationDownload `json:"tools"`
 	// RepoURL is the URL the github runner agent needs to configure itself.
 	RepoURL string `json:"repo_url"`
 	// CallbackUrl is the URL where the instance can send a post, signaling

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -25,7 +25,6 @@ import (
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm-provider-common/params"
-	"github.com/google/go-github/v55/github"
 	"github.com/stretchr/testify/require"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
@@ -211,10 +210,10 @@ func TestGetTools(t *testing.T) {
 		t.Fatalf("failed to resolve to github os type: %s", err)
 	}
 
-	tools := []*github.RunnerApplicationDownload{
+	tools := []params.RunnerApplicationDownload{
 		{
-			OS:           github.String(ghOS),
-			Architecture: github.String(ghArch),
+			OS:           &ghOS,
+			Architecture: &ghArch,
 		},
 	}
 


### PR DESCRIPTION
The go-github package is a huge dependency. This package only needed it for the github tools structure. We copy that structure along with all the accessors, which will allow us to not cascade the update of all providers and garm-provider-common whenever garm itself will have to update go-github.