### PR TITLE
Add InstancePendingForceDelete instance status

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -39,14 +39,15 @@ const (
 )
 
 const (
-	InstanceRunning       InstanceStatus = "running"
-	InstanceStopped       InstanceStatus = "stopped"
-	InstanceError         InstanceStatus = "error"
-	InstancePendingDelete InstanceStatus = "pending_delete"
-	InstanceDeleting      InstanceStatus = "deleting"
-	InstancePendingCreate InstanceStatus = "pending_create"
-	InstanceCreating      InstanceStatus = "creating"
-	InstanceStatusUnknown InstanceStatus = "unknown"
+	InstanceRunning            InstanceStatus = "running"
+	InstanceStopped            InstanceStatus = "stopped"
+	InstanceError              InstanceStatus = "error"
+	InstancePendingDelete      InstanceStatus = "pending_delete"
+	InstancePendingForceDelete InstanceStatus = "pending_force_delete"
+	InstanceDeleting           InstanceStatus = "deleting"
+	InstancePendingCreate      InstanceStatus = "pending_create"
+	InstanceCreating           InstanceStatus = "creating"
+	InstanceStatusUnknown      InstanceStatus = "unknown"
 )
 
 const (


### PR DESCRIPTION
The InstancePendingForceDelete instance status is meant to signal that the operator wishes to forcefully remove the runner in spite of any provider error. This has the potential to orphan resources in your IaaS, but will help in situations in which the operator deems it necessary to ignore such errors. This may include situations in which the provider is misconfigured in GARM or when credentials change or expire.