### PR TITLE
Fix the agent_id json field for Windows userdata

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -355,7 +355,7 @@ function Update-GarmStatus() {
 		}
 
 		if ($AgentID -ne 0) {
-			$body["AgentID"] = $AgentID
+			$body["agent_id"] = $AgentID
 		}
 		Invoke-APICall -Payload $body -CallbackURL $CallbackURL | Out-Null
 	}


### PR DESCRIPTION
This fixes the call to garm when setting the agent id. Without this ID, when manually removing a runner that was bootstrapped using a registration token, garm will not remove it from github. It will eventually reap it, but it should remove it when running the rm command.