### PR TITLE
Explicitly set the users section

### DIFF
--- a/cloudconfig/cloudconfig.go
+++ b/cloudconfig/cloudconfig.go
@@ -34,6 +34,7 @@ func NewDefaultCloudInitConfig() *CloudInit {
 			"curl",
 			"tar",
 		},
+		Users: []string{"default"},
 		SystemInfo: &SystemInfo{
 			DefaultUser: DefaultUser{
 				Name:   defaults.DefaultUser,
@@ -69,6 +70,7 @@ type File struct {
 type CloudInit struct {
 	mux sync.Mutex
 
+	Users             []string    `yaml:"users"`
 	PackageUpgrade    bool        `yaml:"package_upgrade"`
 	Packages          []string    `yaml:"packages,omitempty"`
 	SSHAuthorizedKeys []string    `yaml:"ssh_authorized_keys,omitempty"`


### PR DESCRIPTION
On some cloud-init enabled systems, it's not enough to define the system_info section with the default user. We must also set the users section, even if we only do so to set the "default" user value.