### PR TITLE
feat: symlink cached runner instead of copy

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -126,8 +126,8 @@ if [ -z "$CACHED_RUNNER" ];then
 	sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
 else
 	sendStatus "using cached runner found in $CACHED_RUNNER"
-	sudo cp -a "$CACHED_RUNNER"  "/home/{{ .RunnerUsername }}/actions-runner"
-	sudo chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R "/home/{{ .RunnerUsername }}/actions-runner" || fail "failed to change owner"
+	ln -s "$CACHED_RUNNER"/actions-runner "/home/{{ .RunnerUsername}}/actions-runner" || fail "failed to create symlink"
+	sudo chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R "$CACHED_RUNNER"/actions-runner || fail "failed to change owner"
 	cd /home/{{ .RunnerUsername }}/actions-runner
 fi
 


### PR DESCRIPTION
This should (sometimes dramatically) improve boot times if cache runner image is used.
We currently see that copying those ~500 MB takes around 3 Minutes during boot .. I don't know why it's that slow, and later the disk IO speed seems to be much better, but anyway we could skip that copy step all together.

The only issue is see is if /home is mounted on a different disk than /opt , in this case the symlink would probably not be what you would want. Do you think that is an issue? Am I missing other problems with that?

