### PR TITLE
feat: add toggle to skip runner install

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -110,6 +110,11 @@ function getCachedToolsPath() {
 	return 0
 }
 
+# allow to skip the installation of the runner application
+# this is useful when the runner is already installed in the image
+# and this can save a lot of time during boot
+{{- if ne .ExtraContext.SkipRunnerInstall "true"}}
+
 function downloadAndExtractRunner() {
 	sendStatus "downloading tools from {{ .DownloadURL }}"
 	if [ ! -z "{{ .TempDownloadToken }}" ]; then
@@ -126,7 +131,6 @@ CACHED_RUNNER=$(getCachedToolsPath)
 if [ -z "$CACHED_RUNNER" ];then
 	downloadAndExtractRunner
 	sendStatus "installing dependencies"
-	cd /home/{{ .RunnerUsername }}/actions-runner
 	sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
 else
 	sendStatus "using cached runner found in $CACHED_RUNNER"
@@ -140,8 +144,11 @@ else
 		sudo cp -a "$CACHED_RUNNER/." $RUN_HOME || fail "failed to copy cached runner"
 		sudo chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R "$RUN_HOME" || fail "failed to change owner"
 	fi
-	cd /home/{{ .RunnerUsername }}/actions-runner
 fi
+
+{{- end}}
+
+cd /home/{{ .RunnerUsername }}/actions-runner
 
 
 sendStatus "configuring runner"


### PR DESCRIPTION
This adds a toggle that allows to skip the entire runner installation, both download & install as well as overlay from a cached installation.
This makes sense if the runner application is already installed. This can help to save many seconds during boot of each runner VM instance.

The toggle can be set via extra_spec's extra_context:
```
'{"extra_context": {"SkipRunnerInstall ": "true"}}'
```