### PR TITLE
fix: Adds validation for the new commands

### DIFF
--- a/execution/v0.1.0/execution.go
+++ b/execution/v0.1.0/execution.go
@@ -106,7 +106,7 @@ func (e EnvironmentV010) Validate() error {
 			return fmt.Errorf("missing controller ID")
 		}
 	case common.GetVersionCommand:
-		if semver.IsValid(e.InterfaceVersion) {
+		if !semver.IsValid(e.InterfaceVersion) {
 			return fmt.Errorf("invalid interface version: %s", e.InterfaceVersion)
 		}
 	default:

--- a/execution/v0.1.1/execution.go
+++ b/execution/v0.1.1/execution.go
@@ -112,7 +112,12 @@ func (e EnvironmentV011) Validate() error {
 			return fmt.Errorf("missing controller ID")
 		}
 	case common.GetVersionCommand:
-		if semver.IsValid(e.InterfaceVersion) {
+		if !semver.IsValid(e.InterfaceVersion) {
+			return fmt.Errorf("invalid interface version: %s", e.InterfaceVersion)
+		}
+	case common.ValidatePoolInfoCommand, common.GetConfigJSONSchemaCommand,
+		common.GetExtraSpecsJSONSchemaCommand:
+		if !semver.IsValid(e.InterfaceVersion) && e.InterfaceVersion == common.Version010 {
 			return fmt.Errorf("invalid interface version: %s", e.InterfaceVersion)
 		}
 	default:


### PR DESCRIPTION
Fixes error when trying to run the following commands on a provider:
- `GetVersion` (v0.1.0, v0.1.1)
- `ValidatePoolInfo` (v0.1.1)
- `GetConfigJSONSchema` (v0.1.1)
- `GetExtraSpecsJSONSchema` (v0.1.1)