### PR TITLE
Update execution package

### DIFF
--- a/execution/common/commands.go
+++ b/execution/common/commands.go
@@ -42,9 +42,10 @@ const (
 
 // V0.1.1 commands
 const (
-	ValidatePoolInfoCommand        ExecutionCommand = "ValidatePoolInfo"
-	GetConfigJSONSchemaCommand     ExecutionCommand = "GetConfigJSONSchema"
-	GetExtraSpecsJSONSchemaCommand ExecutionCommand = "GetExtraSpecsJSONSchema"
+	GetSupportedInterfaceVersionsCommand ExecutionCommand = "GetSupportedInterfaceVersions"
+	ValidatePoolInfoCommand              ExecutionCommand = "ValidatePoolInfo"
+	GetConfigJSONSchemaCommand           ExecutionCommand = "GetConfigJSONSchema"
+	GetExtraSpecsJSONSchemaCommand       ExecutionCommand = "GetExtraSpecsJSONSchema"
 )
 
 const (

--- a/execution/v0.1.0/execution_test.go
+++ b/execution/v0.1.0/execution_test.go
@@ -380,7 +380,7 @@ func TestRun(t *testing.T) {
 			mockInstance: tc.providerInstance,
 		}
 
-		out, err := Run(context.Background(), &testExternalProvider, tc.providerEnv)
+		out, err := tc.providerEnv.Run(context.Background(), &testExternalProvider)
 
 		if tc.expectedErrMsg == "" {
 			require.NoError(t, err)

--- a/execution/v0.1.1/execution_test.go
+++ b/execution/v0.1.1/execution_test.go
@@ -88,6 +88,11 @@ func (p *testExternalProvider) GetVersion(context.Context) string {
 	return "v0.1.1"
 }
 
+func (p *testExternalProvider) GetSupportedInterfaceVersions(context.Context) []string {
+	//TODO: implement
+	return []string{"v0.1.0", "v0.1.1"}
+}
+
 func (p *testExternalProvider) ValidatePoolInfo(context.Context, string, string, string, string) error {
 	//TODO: implement
 	return nil
@@ -161,7 +166,6 @@ func TestValidateEnvironment(t *testing.T) {
 				PoolID:             "pool-id",
 				ProviderConfigFile: tmpfile.Name(),
 				InstanceID:         "instance-id",
-				InterfaceVersion:   "v0.1.1",
 				BootstrapParams: params.BootstrapInstance{
 					Name: "instance-name",
 				},
@@ -396,7 +400,7 @@ func TestRun(t *testing.T) {
 			mockInstance: tc.providerInstance,
 		}
 
-		out, err := Run(context.Background(), &testExternalProvider, tc.providerEnv)
+		out, err := tc.providerEnv.Run(context.Background(), &testExternalProvider)
 
 		if tc.expectedErrMsg == "" {
 			require.NoError(t, err)

--- a/execution/v0.1.1/interface.go
+++ b/execution/v0.1.1/interface.go
@@ -26,6 +26,8 @@ import (
 type ExternalProvider interface {
 	// The common ExternalProvider interface
 	common.ExternalProvider
+	// GetSupportedInterfaceVersions will return the supported interface versions.
+	GetSupportedInterfaceVersions(ctx context.Context) []string
 	// ValidatePoolInfo will validate the pool info and return an error if it's not valid.
 	ValidatePoolInfo(ctx context.Context, image string, flavor string, providerConfig string, extraspecs string) error
 	// GetConfigJSONSchema will return the JSON schema for the provider's configuration.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	golang.org/x/crypto v0.26.0
-	golang.org/x/mod v0.20.0
 	golang.org/x/sys v0.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 h1:xzABM9let0HLLq
 github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569/go.mod h1:2Ly+NIftZN4de9zRmENdYbvPQeaVIYKWpLFStLFEBgI=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
 golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
-golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
-golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
- Updates `func GetEnvironment(version ...string)` to get the environment based on the version received from external-provider
- Updates `Run()` to be a method of the `Environment struct`
- Removes the need for a common `ExternalProvider interface` in favor of doing a cast during the call of `Run()`
- Removes `semver` dependency
- Adds for v0.1.1 a new command `GetSupportedInterfaceVersions`