### PR TITLE
Source env.sh when JIT config is used

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -182,6 +182,11 @@ fi
 
 AGENT_ID=""
 {{- if .UseJITConfig }}
+if [ -f "$RUN_HOME/env.sh" ];then
+	pushd $RUN_HOME
+	source env.sh
+	popd
+fi
 sudo systemctl start $SVC_NAME || fail "failed to start service"
 {{- else}}
 sendStatus "starting service"


### PR DESCRIPTION
When the runner gets set up via config.sh or when the run.sh script is used with a JIT config, the env.sh script is sourced, setting up some environment files inside the runner folder. This change emulates that.

Fixes: #39 