### PR TITLE
Add "deleted" instance status

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -45,6 +45,7 @@ const (
 	InstancePendingDelete      InstanceStatus = "pending_delete"
 	InstancePendingForceDelete InstanceStatus = "pending_force_delete"
 	InstanceDeleting           InstanceStatus = "deleting"
+	InstanceDeleted            InstanceStatus = "deleted"
 	InstancePendingCreate      InstanceStatus = "pending_create"
 	InstanceCreating           InstanceStatus = "creating"
 	InstanceStatusUnknown      InstanceStatus = "unknown"


### PR DESCRIPTION
This adds the "deleted" instance status constant. It can be used if we want providers to mark the instance as being deleted from the provider and to signal a controller somewhere to remove it from the database.