### PR TITLE
Increase websocket message size

### DIFF
--- a/util/websocket/reader.go
+++ b/util/websocket/reader.go
@@ -24,7 +24,7 @@ const (
 	pingPeriod = (pongWait * 9) / 10
 
 	// Maximum message size allowed from peer.
-	maxMessageSize = 16384 // 16 KB
+	maxMessageSize = 1048576 // 1 MB
 )
 
 // MessageHandler is a function that processes a message received from a websocket connection.


### PR DESCRIPTION
The message size is quite small for streaming large amounts of text. This change increases it to 1 MB.