### PR TITLE
Remove erroneous check

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -334,7 +334,6 @@ func CompressData(data []byte) ([]byte, error) {
 func SanitizeCABundle(bundle []byte) ([]byte, error) {
 	seen := map[string]struct{}{}
 	var buf bytes.Buffer
-	found := false
 
 	rest := bundle
 	for {
@@ -343,7 +342,6 @@ func SanitizeCABundle(bundle []byte) ([]byte, error) {
 		if block == nil {
 			break
 		}
-		found = true
 		if _, err := x509.ParseCertificates(block.Bytes); err != nil {
 			return nil, fmt.Errorf("invalid certificate in PEM bundle: %w", err)
 		}
@@ -356,8 +354,6 @@ func SanitizeCABundle(bundle []byte) ([]byte, error) {
 		}
 		seen[key] = struct{}{}
 	}
-	if !found {
-		return nil, fmt.Errorf("no valid PEM blocks found in bundle")
-	}
+
 	return buf.Bytes(), nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -381,10 +381,4 @@ func TestSanitizeCABundle(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid certificate in PEM bundle")
 	})
-
-	t.Run("no valid PEM blocks", func(t *testing.T) {
-		_, err := SanitizeCABundle([]byte("not a pem bundle"))
-		require.Error(t, err)
-		require.EqualError(t, err, "no valid PEM blocks found in bundle")
-	})
 }


### PR DESCRIPTION
If we encounter an invalid pem block, we error out. An empty byte array should not trigger an error.